### PR TITLE
Add typespec to the `Bamboo.Mailer.deliver/1` function

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -79,6 +79,7 @@ defmodule Bamboo.Mailer do
 
       defp build_config, do: Bamboo.Mailer.build_config(__MODULE__, unquote(otp_app))
 
+      @spec deliver(Bamboo.Email.t) :: no_return()
       def deliver(_email) do
         raise """
         you called deliver/1, but it has been renamed to deliver_now/1 to add clarity.


### PR DESCRIPTION
This function only raises an exception as the deprecation message. However, missing typespec results in a warning from Dialyzer (when ran with the `-Werror_handling` flag) for a module that is using `Bamboo.Mailer`:

    apps/core/lib/core/mailer.ex:2: Function deliver/1 only terminates with explicit exception